### PR TITLE
Change type assertion to type cast

### DIFF
--- a/github/resource_github_dependabot_organization_secret_repositories.go
+++ b/github/resource_github_dependabot_organization_secret_repositories.go
@@ -55,7 +55,7 @@ func resourceGithubDependabotOrganizationSecretRepositoriesCreateOrUpdate(d *sch
 
 	ids := selectedRepositories.(*schema.Set).List()
 	for _, id := range ids {
-		selectedRepositoryIDs = append(selectedRepositoryIDs, id.(int64))
+		selectedRepositoryIDs = append(selectedRepositoryIDs, int64(id.(int)))
 	}
 
 	_, err = client.Dependabot.SetSelectedReposForOrgSecret(ctx, owner, secretName, selectedRepositoryIDs)


### PR DESCRIPTION
A repository ID is not an int64 as can be seen on https://github.com/integrations/terraform-provider-github/blob/46650cb363ded7c10bc780998fa3166d3dd63daf/github/data_source_github_repository.go#L216

The code is now the same as other places where `selected_repository_ids` is used (for example [here](https://github.com/integrations/terraform-provider-github/blob/46650cb363ded7c10bc780998fa3166d3dd63daf/github/resource_github_dependabot_organization_secret.go#L105)).

Locally tested with our Terraform project.

<!-- Please refer to our contributing docs for any questions on submitting a pull request -->
<!-- Issues are required for both bug fixes and features. -->

----

### Before the change?
* The values in `selected_repository_ids` are asserted of being of the `int64` type.

### After the change?
* The values in `selected_repository_ids` are casted to an `int64`.

### Pull request checklist
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been reviewed and added / updated if needed (for bug fixes / features)

### Does this introduce a breaking change?
<!-- If this introduces a breaking change make sure to note it here any what the impact might be -->

Please see our docs on [breaking changes](https://github.com/octokit/.github/blob/master/community/breaking_changes.md) to help!

- [ ] Yes
- [x] No

----

